### PR TITLE
Remove extra trailing \r\n

### DIFF
--- a/sip/message/SIPRequest.go
+++ b/sip/message/SIPRequest.go
@@ -255,7 +255,7 @@ func (this *SIPRequest) String() string {
 	} else {
 		retval = this.SIPMessage.String()
 	}
-	return retval + core.SIPSeparatorNames_NEWLINE
+	return retval
 }
 
 // /** ALias for encode above.


### PR DESCRIPTION
Both [ContentLengthImpl.String()](/rainliu/gosips/blob/3258635099a5258efebd30c2be26b04e5fa8d894/sip/header/ContentLengthImpl.go#L93) and [SIPMessage.String()](/rainliu/gosips/blob/3258635099a5258efebd30c2be26b04e5fa8d894/sip/message/SIPMessage.go#L360) append `core.SIPSeparatorNames_NEWLINE`.

In addition to `SIPRequest.String()` adding another newline, empty messages will have 3 newlines, resulting in responses like:

`SIP/2.0 400 Content-Length mis-match`
